### PR TITLE
Add meta test to verify runner, change npm test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "babel src -d dist --source-maps --copy-files",
     "debug": "node --nolazy --inspect-brk=9229 ./src/main.js",
     "start": "node ./dist/main.js",
-    "test": "make test"
+    "test": "env NODE_ENV=test ./node_modules/.bin/mocha --recursive --reporter spec --timeout 3000"
   },
   "repository": {
     "type": "git",

--- a/test/main.tests.js
+++ b/test/main.tests.js
@@ -1,0 +1,8 @@
+var assert = require('chai').assert
+
+describe("Meta tests", () => {
+    it("should pass", done => {
+        assert.equal(true, true);
+        done();
+    })
+})


### PR DESCRIPTION
`make test` wouldn't work on Windows, probably because I used make from `npm install -g make`.  `npm test` works on Windows and Linux, and `make test` works on Linux.